### PR TITLE
[MRG] Allow Slideshow to be used as a context manager

### DIFF
--- a/present/cli.py
+++ b/present/cli.py
@@ -17,15 +17,7 @@ def cli(filename):
     with open(filename, "r") as f:
         slides = markdown.parse(f.read())
 
-    show = Slideshow(slides)
-    try:
+    with Slideshow(slides) as show:
         show.play()
-    except KeyboardInterrupt:
-        pass
-    finally:
-        # TODO: asciimatics leaves terminal in abnormal state
-        # temp fix till underlying bug is found and fixed
-        if os.name == "posix":
-            os.system("reset")
 
     click.secho("All done! ✨ 🍰 ✨", bold=True)

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -59,16 +59,19 @@ class Slide(Scene):
 
 class Slideshow(object):
     def __init__(self, slides):
-        self.reset = None
+        self.slides = slides
         self.current_slide = 0
-        self.screen = Screen.open()
-        self.reset = [Slide(self, _reset(self.screen), 7, 0)]
-        self.slides = [
-            Slide(self, self.get_effects(slide), slide.fg_color, slide.bg_color)
-            for slide in slides
-        ]
+        self.screen = None
+        self.reset = None
 
         super(Slideshow, self).__init__()
+
+    def __enter__(self):
+        self.screen = Screen.open()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.screen.close()
 
     def get_effects(self, slide):
         effects = []
@@ -112,6 +115,14 @@ class Slideshow(object):
         repeat=True,
         allow_int=False,
     ):
+        self.reset = [Slide(self, _reset(self.screen), 7, 0)]
+
+        self.slides = [
+                Slide(self, self.get_effects(slide), slide.fg_color, slide.bg_color)
+                for slide in self.slides
+        ]
+
+
         # Initialise the Screen for animation.
         self.screen.set_scenes(
             self.slides, unhandled_input=unhandled_input, start_scene=start_scene


### PR DESCRIPTION
Add __enter__ and __exit__ methods. This required re-ordering
some of the initialisation of Slideshow, so that the Screen
object isn't created until __enter__ is called

This makes cleaning up the terminal state more reliable and
removes the need for the os.system() call to reset.