### PR TITLE
add a missed requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requires = [
     "mistune>=2.0.0a4",
     "pyfiglet>=0.8.post1",
     "PyYAML>=5.3.1",
+    "dataclasses==0.7",
 ]
 dev_requires = ["Sphinx>=2.2.1"]
 dev_requires = dev_requires + requires


### PR DESCRIPTION
Due to this [issue](https://github.com/vinayak-mehta/present/issues/49#issue-688855485) I added this requirement in your `setup.py` to solve this requirement with only `pip install present`.