### PR TITLE
[MRG] Delete Untitled.ipynb

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,6 +1,0 @@
-{
- "cells": [],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 4
-}


### PR DESCRIPTION
An empty Jupyter notebook named Untitled.ipynb was added to the repo.

Seemingly looks like a mistake so PR to remove it