### PR TITLE
Add support for ordered lists

### DIFF
--- a/examples/sample.md
+++ b/examples/sample.md
@@ -21,9 +21,9 @@ Each slide should be separated with a ---
 Some controls:
 
 - Basic
-    - Quit: q
-    - Previous slide: b, Left arrow, Page Up
-    - Next slide: n, Space bar, Right arrow, Page Down
+    - Quit: `q`
+    - Previous slide: `b`, `Left arrow`, `Page Up`
+    - Next slide: `n`, `Space bar`, `Right arrow`, `Page Down`
 
 ---
 

--- a/present/slide.py
+++ b/present/slide.py
@@ -46,6 +46,7 @@ class Heading(object):
 class List(object):
     type: str = "list"
     obj: dict = None
+    ordered: bool = False
     fg: int = 0
     attr: int = 2  # Screen.A_NORMAL
     normal: int = 2  # Screen.A_NORMAL
@@ -69,17 +70,23 @@ class List(object):
                 s += child.get("text")
         return s
 
-    def walk(self, obj, text=None, level=0):
+    def walk(self, obj, text=None, level=0, idx=0):
         if text is None:
             text = []
 
         for child in obj.get("children", []):
+            if child.get("type") == "list":
+                idx = -1  # will have child list_item, then the value itself
             if child.get("type") == "block_text":
-                s = (" " * 2 * level) + "• "
+                if self.ordered:
+                    s = (" " * 2 * level) + f"{idx}. "
+                else:
+                    s = (" " * 2 * level) + "• "
                 s += List.render_children(child)
                 text.append(s)
             elif "children" in obj:
-                self.walk(child, text=text, level=level + 1)
+                idx += 1
+                self.walk(child, text=text, level=level + 1, idx=idx)
 
         return text
 
@@ -88,6 +95,7 @@ class List(object):
         return len(self.walk(self.obj))
 
     def render(self):
+        self.ordered = self.obj['ordered']
         return "\n".join(self.walk(self.obj))
 
 

--- a/present/slide.py
+++ b/present/slide.py
@@ -51,15 +51,34 @@ class List(object):
     normal: int = 2  # Screen.A_NORMAL
     bg: int = 7
 
+    @staticmethod
+    def render_children(obj):
+        s = ''
+        for child in obj.get("children", []):
+            if child.get("type") == Text.type:
+                s += Text(obj=child).render()
+            elif child.get("type") == Codespan.type:
+                s += Codespan(obj=child).render()
+            elif child.get("type") == Strong.type:
+                s += Strong(obj=child).render()
+            elif child.get("type") == Emphasis.type:
+                s += Emphasis(obj=child).render()
+            elif child.get("type") == Link.type:
+                s += Link(obj=child).render()
+            elif child.get("text") is not None:
+                s += child.get("text")
+        return s
+
     def walk(self, obj, text=None, level=0):
         if text is None:
             text = []
 
         for child in obj.get("children", []):
-            if child.get("text") is not None:
-                text.append((" " * 2 * level) + "• " + child["text"])
-
-            if "children" in obj:
+            if child.get("type") == "block_text":
+                s = (" " * 2 * level) + "• "
+                s += List.render_children(child)
+                text.append(s)
+            elif "children" in obj:
                 self.walk(child, text=text, level=level + 1)
 
         return text


### PR DESCRIPTION
This is based on #106, so that should either be merged first, or disregarded in favor of this pull request.  Currently they're separate to keep the scope clean(ish).  And they'd conflict if separate.

There's possibly some bugs in the implementation, but the below input works as expected:
```
 1. root1
    1. sub1
    2. sub2
    3. extra one
        1. ssub1
        2. ssub2
 2. root2
    1. sub 3
    2. sub 4
 3. root3
```