### PR TITLE
[MRG] Add syntax highlighting to code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ Note: You can use high resolution images and tweak the terminal font size to get
 
 ### Code blocks
 
+Put the code language after the backticks to get syntax highlighting.
+
 <pre>
-```
+```python
 import os
 
 os.getcwd()

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Note: You can use high resolution images and tweak the terminal font size to get
 
 ### Code blocks
 
-To specify your language for syntax highlighting, put it on the first line after the backticks. If no language is specified, a guess will be made based on the code block.
+To specify your language for syntax highlighting, put it on the first line after the backticks. If no language is specified, no highlighting will be applied.
 
 <pre>
 ```python

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Note: You can use high resolution images and tweak the terminal font size to get
 
 ### Code blocks
 
-Put the code language after the backticks to get syntax highlighting.
+To specify your language for syntax highlighting, put it on the first line after the backticks. If no language is specified, a guess will be made based on the code block.
 
 <pre>
 ```python

--- a/examples/sample.md
+++ b/examples/sample.md
@@ -64,7 +64,7 @@ columns, rows = shutil.get_terminal_size()
 
 ## Images
 
-```
+```md
 ![RC](images/recurse.png)
 ```
 

--- a/present/effects.py
+++ b/present/effects.py
@@ -138,19 +138,6 @@ def _base(screen, element, row, fg_color, bg_color, attr=0):
     return [base]
 
 
-def _code(screen, element, row):
-    code = Print(
-        screen,
-        Text(element.render()),
-        row,
-        colour=Screen.COLOUR_WHITE,
-        bg=Screen.COLOUR_BLACK,
-        transparent=False,
-    )
-
-    return [code]
-
-
 def _codio(screen, element, row):
     codio = Print(
         screen,

--- a/present/effects.py
+++ b/present/effects.py
@@ -17,7 +17,7 @@ from asciimatics.parsers import AnsiTerminalParser
 from asciimatics.strings import ColouredText
 
 from pygments import highlight
-from pygments.lexers import get_lexer_by_name
+from pygments.lexers import get_lexer_by_name, guess_lexer
 from pygments.formatters import Terminal256Formatter
 
 ATTRS = {
@@ -43,7 +43,7 @@ class HighlightedCode(StaticRenderer):
     def __init__(self, code, lang):
         super(HighlightedCode, self).__init__()
         self._images = [code]
-        self.lexer = get_lexer_by_name(lang)
+        self.lexer = get_lexer_by_name(lang) if lang is not None else guess_lexer(code)
 
     @property
     def rendered_text(self):

--- a/present/effects.py
+++ b/present/effects.py
@@ -175,6 +175,8 @@ def _code(screen, element, row):
         HighlightedCode(element.render(), element.lang()),
         row,
         column,
+        colour=Screen.COLOUR_WHITE,
+        bg=Screen.COLOUR_BLACK,
         transparent=False,
     )
 

--- a/present/effects.py
+++ b/present/effects.py
@@ -17,7 +17,7 @@ from asciimatics.parsers import AnsiTerminalParser
 from asciimatics.strings import ColouredText
 
 from pygments import highlight
-from pygments.lexers import get_lexer_by_name, guess_lexer
+from pygments.lexers import get_lexer_by_name
 from pygments.formatters import Terminal256Formatter
 
 ATTRS = {
@@ -43,19 +43,23 @@ class HighlightedCode(StaticRenderer):
     def __init__(self, code, lang):
         super(HighlightedCode, self).__init__()
         self._images = [code]
-        self.lexer = get_lexer_by_name(lang) if lang is not None else guess_lexer(code)
+        self.lang = lang
 
     @property
     def rendered_text(self):
+        if self.lang is None:
+            return super().rendered_text
+
         if len(self._plain_images) <= 0:
             self._convert_images()
 
+        lexer = get_lexer_by_name(self.lang)
         highlighted_block = []
         colour_map = []
 
         # We're only expecting this renderer to have one code block
         for line in self._plain_images[0]:
-            highlighted_line = highlight(line, self.lexer, Terminal256Formatter())
+            highlighted_line = highlight(line, lexer, Terminal256Formatter())
             encoded_text = ColouredText(highlighted_line, AnsiTerminalParser())
 
             highlighted_block.append(encoded_text)

--- a/present/slide.py
+++ b/present/slide.py
@@ -92,7 +92,7 @@ class BlockCode(object):
         lines.insert(0, top)
         lines.append(bottom)
 
-        return lines
+        return "\n".join(lines)
 
     @property
     def size(self):
@@ -101,7 +101,7 @@ class BlockCode(object):
     def lang(self):
         return self.obj["info"]
 
-    def padded_lines(self):
+    def render(self):
         return self.pad(self.obj["text"])
 
 
@@ -404,12 +404,12 @@ class Slide(object):
         self.has_style = False
         self.has_effect = False
         self.has_image = False
+        self.has_code = False
         self.has_codio = False
         self.style = {}
         self.effect = None
         self.fg_color = 0
         self.bg_color = 7
-        self.code_blocks = None
 
         _elements = []
 
@@ -426,8 +426,7 @@ class Slide(object):
                 self.has_image = True
 
             if e.type == "code":
-                # This list will get built by the Slideshow
-                self.code_blocks = []
+                self.has_code = True
 
             if e.type == "codio":
                 self.has_codio = True
@@ -470,10 +469,6 @@ class Slide(object):
         for e in self.elements:
             e.fg = self.fg_color
             e.bg = self.bg_color
-
-    @property
-    def has_code(self):
-        return type(self.code_blocks) is list
 
     def __repr__(self):
         return f"<Slide elements={self.elements} has_style={self.has_style} has_code={self.has_code} fg_color={self.fg_color} bg_color={self.bg_color}>"

--- a/present/slide.py
+++ b/present/slide.py
@@ -101,6 +101,12 @@ class BlockCode(object):
     def render(self):
         return self.pad(self.obj["text"])
 
+    def lang(self):
+        return self.obj["info"]
+
+    def lines(self):
+        return self.obj["text"].splitlines()
+
 
 @dataclass
 class Codio(object):

--- a/present/slide.py
+++ b/present/slide.py
@@ -404,13 +404,12 @@ class Slide(object):
         self.has_style = False
         self.has_effect = False
         self.has_image = False
-        self.has_code = False
         self.has_codio = False
         self.style = {}
         self.effect = None
         self.fg_color = 0
         self.bg_color = 7
-        self.code_blocks = []
+        self.code_blocks = None
 
         _elements = []
 
@@ -427,7 +426,8 @@ class Slide(object):
                 self.has_image = True
 
             if e.type == "code":
-                self.has_code = True
+                # This list will get built by the Slideshow
+                self.code_blocks = []
 
             if e.type == "codio":
                 self.has_codio = True
@@ -470,6 +470,10 @@ class Slide(object):
         for e in self.elements:
             e.fg = self.fg_color
             e.bg = self.bg_color
+
+    @property
+    def has_code(self):
+        return type(self.code_blocks) is list
 
     def __repr__(self):
         return f"<Slide elements={self.elements} has_style={self.has_style} has_code={self.has_code} fg_color={self.fg_color} bg_color={self.bg_color}>"

--- a/present/slide.py
+++ b/present/slide.py
@@ -410,6 +410,7 @@ class Slide(object):
         self.effect = None
         self.fg_color = 0
         self.bg_color = 7
+        self.code_blocks = []
 
         _elements = []
 

--- a/present/slide.py
+++ b/present/slide.py
@@ -92,20 +92,17 @@ class BlockCode(object):
         lines.insert(0, top)
         lines.append(bottom)
 
-        return "\n".join(lines)
+        return lines
 
     @property
     def size(self):
         return len(self.obj["text"].splitlines())
 
-    def render(self):
-        return self.pad(self.obj["text"])
-
     def lang(self):
         return self.obj["info"]
 
-    def lines(self):
-        return self.obj["text"].splitlines()
+    def padded_lines(self):
+        return self.pad(self.obj["text"])
 
 
 @dataclass

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -28,7 +28,11 @@ class Slide(Scene):
         self.show = show
         self.fg_color = fg_color
         self.bg_color = bg_color
-        super(Slide, self).__init__(effects)
+
+        code_blocks = [item for item in effects if type(item) is tuple]
+        stripped_effects = [e for e in effects if type(e) is not tuple]
+
+        super(Slide, self).__init__(stripped_effects)
 
     def _reset(self):
         for effect in self._effects:
@@ -112,7 +116,8 @@ class Slideshow(object):
         pad = 2
         for e in elements:
             if e.type == "code":
-                effects.extend(_code(self.screen, e, row))
+                # effects.extend(_code(self.screen, e, row))
+                effects.append((self.screen, e, row))
                 pad = 4
             elif e.type == "codio":
                 effects.extend(_codio(self.screen, e, row))

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -8,7 +8,6 @@ from asciimatics.effects import Print
 from asciimatics.event import KeyboardEvent
 from asciimatics.exceptions import ResizeScreenError, StopApplication
 
-
 from .effects import (
     _reset,
     _base,
@@ -29,7 +28,6 @@ class Slide(Scene):
         self.show = show
         self.fg_color = fg_color
         self.bg_color = bg_color
-
         super(Slide, self).__init__(effects)
 
     def _reset(self):
@@ -191,7 +189,6 @@ class Slideshow(object):
 
                 a = time.time()
                 self.screen.draw_next_frame(repeat=repeat)
-
                 if self.screen.has_resized():
                     if stop_on_resize:
                         self.screen._scenes[self.screen._scene_index].exit()

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -22,6 +22,23 @@ from .effects import (
     Codio,
 )
 
+from pygments import highlight
+from pygments.lexers import get_lexer_by_name
+from pygments.formatters import Terminal256Formatter
+
+from asciimatics.parsers import AsciimaticsParser
+from asciimatics.strings import ColouredText
+
+
+def highlight_code(code, lang):
+    lexer = get_lexer_by_name(lang)
+    coded_text = highlight(code, lexer, Terminal256Formatter())
+
+    return ColouredText(
+        coded_text,
+        AsciimaticsParser(),
+    )
+
 
 class Slide(Scene):
     def __init__(self, show, effects, fg_color, bg_color):
@@ -29,7 +46,7 @@ class Slide(Scene):
         self.fg_color = fg_color
         self.bg_color = bg_color
 
-        code_blocks = [item for item in effects if type(item) is tuple]
+        self.code_blocks = [item for item in effects if type(item) is tuple]
         stripped_effects = [e for e in effects if type(e) is not tuple]
 
         super(Slide, self).__init__(stripped_effects)
@@ -194,6 +211,22 @@ class Slideshow(object):
 
                 a = time.time()
                 self.screen.draw_next_frame(repeat=repeat)
+
+                cur_slide = self.slides[self.current_slide]
+                # Dividide the width by 3
+                left_start = int(self.screen.dimensions[1] / 3)
+
+                if cur_slide.code_blocks:
+                    blocks = cur_slide.code_blocks
+
+                    for block in blocks:
+                        text = highlight_code("print('Testing') ", "python")
+                        self.screen.paint(
+                            text.raw_text,
+                            left_start,
+                            block[2],
+                            colour_map=text.colour_map,
+                        )
                 if self.screen.has_resized():
                     if stop_on_resize:
                         self.screen._scenes[self.screen._scene_index].exit()

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -36,7 +36,7 @@ def render_code_block(screen, block, row):
     lexer = get_lexer_by_name(block.lang())
 
     cur_row = row
-    for line in block.lines():
+    for line in block.padded_lines():
         coded_text = highlight(line, lexer, Terminal256Formatter())
         text = ColouredText(
             coded_text,

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -51,11 +51,12 @@ def render_code_block(screen, block, row):
 
 
 class Slide(Scene):
-    def __init__(self, show, effects, code_blocks, fg_color, bg_color):
+    def __init__(self, show, slide):
         self.show = show
-        self.fg_color = fg_color
-        self.bg_color = bg_color
-        self.code_blocks = code_blocks
+        self.fg_color = slide.fg_color
+        self.bg_color = slide.bg_color
+        self.code_blocks = slide.code_blocks
+        effects = show.build_scene(slide)
 
         super(Slide, self).__init__(effects)
 
@@ -122,7 +123,7 @@ class Slideshow(object):
     def __exit__(self, type, value, traceback):
         self.screen.close()
 
-    def get_effects(self, slide):
+    def build_scene(self, slide):
         effects = []
         transparent = True
         elements = slide.elements
@@ -170,18 +171,9 @@ class Slideshow(object):
         repeat=True,
         allow_int=False,
     ):
-        self.reset = [Slide(self, _reset(self.screen), None, 7, 0)]
+        self.reset = [Scene(_reset(self.screen))]
 
-        self.slides = [
-            Slide(
-                self,
-                self.get_effects(slide),
-                slide.code_blocks,
-                slide.fg_color,
-                slide.bg_color,
-            )
-            for slide in self.slides
-        ]
+        self.slides = [Slide(self, slide) for slide in self.slides]
 
         # Initialise the Screen for animation.
         self.screen.set_scenes(

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -31,11 +31,9 @@ from asciimatics.strings import ColouredText
 
 
 def render_code_block(screen, block, row):
-    lang = block.lang()
-    code = "print('Testing')"
     # Dividide the width by 3
     left_start = int(screen.dimensions[1] / 3)
-    lexer = get_lexer_by_name(lang)
+    lexer = get_lexer_by_name(block.lang())
 
     cur_row = row
     for line in block.lines():
@@ -224,13 +222,13 @@ class Slideshow(object):
                 a = time.time()
                 self.screen.draw_next_frame(repeat=repeat)
 
-                cur_slide = self.slides[self.current_slide]
+                if self.current_slide < len(self.slides) and (
+                    code_blocks := self.slides[self.current_slide].code_blocks
+                ):
+                    for tpl in code_blocks:
+                        block_code, row = tpl
+                        render_code_block(self.screen, block_code, row)
 
-                if cur_slide.code_blocks:
-                    blocks = cur_slide.code_blocks
-
-                    for block in blocks:
-                        render_code_block(self.screen, block[0], block[1])
                 if self.screen.has_resized():
                     if stop_on_resize:
                         self.screen._scenes[self.screen._scene_index].exit()

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -7,6 +7,12 @@ from asciimatics.screen import Screen
 from asciimatics.effects import Print
 from asciimatics.event import KeyboardEvent
 from asciimatics.exceptions import ResizeScreenError, StopApplication
+from asciimatics.parsers import AnsiTerminalParser
+from asciimatics.strings import ColouredText
+
+from pygments import highlight
+from pygments.lexers import get_lexer_by_name
+from pygments.formatters import Terminal256Formatter
 
 from .effects import (
     _reset,
@@ -21,17 +27,10 @@ from .effects import (
     Codio,
 )
 
-from pygments import highlight
-from pygments.lexers import get_lexer_by_name
-from pygments.formatters import Terminal256Formatter
-
-from asciimatics.parsers import AnsiTerminalParser
-from asciimatics.strings import ColouredText
-
 
 def render_code_block(screen, block, row):
     # Divide the width by 3
-    left_start = int(screen.dimensions[1] / 3)
+    column = int(screen.dimensions[1] / 3)
     lexer = get_lexer_by_name(block.lang())
 
     for cur_row, line in enumerate(block.padded_lines(), start=row):
@@ -42,7 +41,7 @@ def render_code_block(screen, block, row):
         )
         screen.paint(
             text,
-            left_start,
+            column,
             cur_row,
             colour_map=text.colour_map,
         )

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -11,7 +11,6 @@ from asciimatics.exceptions import ResizeScreenError, StopApplication
 from .effects import (
     _reset,
     _base,
-    _code,
     _codio,
     _image,
     _fireworks,

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -26,7 +26,7 @@ from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters import Terminal256Formatter
 
-from asciimatics.parsers import AsciimaticsParser
+from asciimatics.parsers import AnsiTerminalParser
 from asciimatics.strings import ColouredText
 
 
@@ -40,10 +40,10 @@ def render_code_block(screen, block, row):
         coded_text = highlight(line, lexer, Terminal256Formatter())
         text = ColouredText(
             coded_text,
-            AsciimaticsParser(),
+            AnsiTerminalParser(),
         )
         screen.paint(
-            text.raw_text,
+            text,
             left_start,
             cur_row,
             colour_map=text.colour_map,

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -31,22 +31,26 @@ from asciimatics.strings import ColouredText
 
 
 def render_code_block(screen, block, row):
-    lang = "python"
+    lang = block.lang()
     code = "print('Testing')"
     # Dividide the width by 3
     left_start = int(screen.dimensions[1] / 3)
     lexer = get_lexer_by_name(lang)
-    coded_text = highlight(code, lexer, Terminal256Formatter())
-    text = ColouredText(
-        coded_text,
-        AsciimaticsParser(),
-    )
-    screen.paint(
-        text.raw_text,
-        left_start,
-        row,
-        colour_map=text.colour_map,
-    )
+
+    cur_row = row
+    for line in block.lines():
+        coded_text = highlight(line, lexer, Terminal256Formatter())
+        text = ColouredText(
+            coded_text,
+            AsciimaticsParser(),
+        )
+        screen.paint(
+            text.raw_text,
+            left_start,
+            cur_row,
+            colour_map=text.colour_map,
+        )
+        cur_row += 1
 
 
 class Slide(Scene):

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -51,15 +51,13 @@ def render_code_block(screen, block, row):
 
 
 class Slide(Scene):
-    def __init__(self, show, effects, fg_color, bg_color):
+    def __init__(self, show, effects, code_blocks, fg_color, bg_color):
         self.show = show
         self.fg_color = fg_color
         self.bg_color = bg_color
+        self.code_blocks = code_blocks
 
-        self.code_blocks = [item for item in effects if type(item) is tuple]
-        stripped_effects = [e for e in effects if type(e) is not tuple]
-
-        super(Slide, self).__init__(stripped_effects)
+        super(Slide, self).__init__(effects)
 
     def _reset(self):
         for effect in self._effects:
@@ -143,7 +141,8 @@ class Slideshow(object):
         pad = 2
         for e in elements:
             if e.type == "code":
-                effects.append((e, row))
+                # Add the element + row to the slide's code_blocks list
+                slide.code_blocks.append((e, row))
                 pad = 4
             elif e.type == "codio":
                 effects.extend(_codio(self.screen, e, row))
@@ -171,10 +170,16 @@ class Slideshow(object):
         repeat=True,
         allow_int=False,
     ):
-        self.reset = [Slide(self, _reset(self.screen), 7, 0)]
+        self.reset = [Slide(self, _reset(self.screen), None, 7, 0)]
 
         self.slides = [
-            Slide(self, self.get_effects(slide), slide.fg_color, slide.bg_color)
+            Slide(
+                self,
+                self.get_effects(slide),
+                slide.code_blocks,
+                slide.fg_color,
+                slide.bg_color,
+            )
             for slide in self.slides
         ]
 

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -30,12 +30,11 @@ from asciimatics.strings import ColouredText
 
 
 def render_code_block(screen, block, row):
-    # Dividide the width by 3
+    # Divide the width by 3
     left_start = int(screen.dimensions[1] / 3)
     lexer = get_lexer_by_name(block.lang())
 
-    cur_row = row
-    for line in block.padded_lines():
+    for cur_row, line in enumerate(block.padded_lines(), start=row):
         coded_text = highlight(line, lexer, Terminal256Formatter())
         text = ColouredText(
             coded_text,
@@ -47,7 +46,6 @@ def render_code_block(screen, block, row):
             cur_row,
             colour_map=text.colour_map,
         )
-        cur_row += 1
 
 
 class Slide(Scene):

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -30,13 +30,22 @@ from asciimatics.parsers import AsciimaticsParser
 from asciimatics.strings import ColouredText
 
 
-def highlight_code(code, lang):
+def render_code_block(screen, block, row):
+    lang = "python"
+    code = "print('Testing')"
+    # Dividide the width by 3
+    left_start = int(screen.dimensions[1] / 3)
     lexer = get_lexer_by_name(lang)
     coded_text = highlight(code, lexer, Terminal256Formatter())
-
-    return ColouredText(
+    text = ColouredText(
         coded_text,
         AsciimaticsParser(),
+    )
+    screen.paint(
+        text.raw_text,
+        left_start,
+        row,
+        colour_map=text.colour_map,
     )
 
 
@@ -212,20 +221,12 @@ class Slideshow(object):
                 self.screen.draw_next_frame(repeat=repeat)
 
                 cur_slide = self.slides[self.current_slide]
-                # Dividide the width by 3
-                left_start = int(self.screen.dimensions[1] / 3)
 
                 if cur_slide.code_blocks:
                     blocks = cur_slide.code_blocks
 
                     for block in blocks:
-                        text = highlight_code("print('Testing') ", "python")
-                        self.screen.paint(
-                            text.raw_text,
-                            left_start,
-                            block[1],
-                            colour_map=text.colour_map,
-                        )
+                        render_code_block(self.screen, block[0], block[1])
                 if self.screen.has_resized():
                     if stop_on_resize:
                         self.screen._scenes[self.screen._scene_index].exit()

--- a/present/slideshow.py
+++ b/present/slideshow.py
@@ -133,8 +133,7 @@ class Slideshow(object):
         pad = 2
         for e in elements:
             if e.type == "code":
-                # effects.extend(_code(self.screen, e, row))
-                effects.append((self.screen, e, row))
+                effects.append((e, row))
                 pad = 4
             elif e.type == "codio":
                 effects.extend(_codio(self.screen, e, row))
@@ -224,7 +223,7 @@ class Slideshow(object):
                         self.screen.paint(
                             text.raw_text,
                             left_start,
-                            block[2],
+                            block[1],
                             colour_map=text.colour_map,
                         )
                 if self.screen.has_resized():

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ requires = [
     "Click>=7.0",
     "mistune>=2.0.0a4",
     "pyfiglet>=0.8.post1",
+    "Pygments>=2.10.0",
     "PyYAML>=5.3.1",
 ]
 dev_requires = ["black>=20.8b1", "Sphinx>=2.2.1"]


### PR DESCRIPTION
## Description
This PR adds support for syntax highlighting on code blocks using `pygments`.

### Related issues

- #101
- #109

## Screenshots
Based on this markdown:

`````
## Code blocks

```python
print("This is a test")
```

Foo

```js
const myFunc = (name, num) => {
  return [name, num + 4]
}

console.log(`Data is ${myFunc('John')[0]}`);
```

---
`````

Here is a screenshot of the current output:

![image](https://user-images.githubusercontent.com/2008881/132265903-edd2c6e2-6a5d-48f1-9204-0ee1aa59993a.png)

With `asciimatics` version `1.13.1.dev38+g1fde70e`, the [bug relating to parenthesis rendering is fixed](https://github.com/peterbrittain/asciimatics/issues/326#issuecomment-914041824):

![image](https://user-images.githubusercontent.com/2008881/132369698-92a3d8f7-751c-4d7d-b295-ff8662533a76.png)


## Next steps

Here are the next steps just for this PR. I'm not planning on adding support for changing the styling theme - that can come later.
I'm planning on refactoring and cleaning up, but feel free to offer any other suggestions.

- [x] Ensure whitespace has background to match rest of block
- [x] Stop code from being visually truncated
- [x] Pad the block with a border of dark background squares
- [x] Make sure multiple blocks can be rendered on same slide
- [ ] Update `docs/_static/demo.gif` to show the new highlighting feature
- [ ] Update `asciimatics` version to get bugfix when possible