### PR TITLE
[MRG] Implements start from slide feature

### DIFF
--- a/present/cli.py
+++ b/present/cli.py
@@ -9,10 +9,24 @@ from .slideshow import Slideshow
 
 @click.command()
 @click.argument("filename", type=click.Path(exists=True))
-def cli(filename):
+@click.option(
+    "--start",
+    "-s",
+    type=click.INT,
+    default=0,
+    show_default=True,
+    help="start from a specific slide number",
+)
+def cli(filename, start):
     """present: A terminal-based presentation tool with colors and effects."""
 
     slides = Markdown(filename).parse()
+
+    assert (
+        0 <= start < len(slides)
+    ), f"invalid starting slide number ({start}), must be between 0 and {len(slides)-1}"
+    if start > 0:  # rotate slides so that requested starting slide is first
+        slides = slides[start:] + slides[:start]
 
     with Slideshow(slides) as show:
         show.play()


### PR DESCRIPTION
Implements #98 and allows presentation to be started from any slide

For example,

```bash
present --start 3 examples/sample.md
```

starts the presentation from the 4th slide onwards

CLI option naming and whether to use 0-based or 1-based indexing is up to the maintainers.